### PR TITLE
新增高亮显示

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  * @contact  eric@zhu.email
  * @license  https://github.com/hyperf-ext/scout/blob/master/LICENSE
  */
+
 namespace HyperfExt\Scout;
 
 use Elasticsearch\Client;
@@ -52,18 +53,18 @@ class Engine
             $body[] = [
                 'update' => [
                     '_index' => $model->searchableAs(),
-                    '_id' => $model->getScoutKey(),
+                    '_id'    => $model->getScoutKey(),
                 ],
             ];
             $body[] = [
-                'doc' => $doc,
+                'doc'           => $doc,
                 'doc_as_upsert' => true,
             ];
         }
 
         $this->elasticsearch->bulk([
             'refresh' => config('scout.doc_refresh', true),
-            'body' => $body,
+            'body'    => $body,
         ]);
     }
 
@@ -82,14 +83,14 @@ class Engine
             $body[] = [
                 'delete' => [
                     '_index' => $model->searchableAs(),
-                    '_id' => $model->getScoutKey(),
+                    '_id'    => $model->getScoutKey(),
                 ],
             ];
         }
 
         $this->elasticsearch->bulk([
             'refresh' => config('scout.document_refresh', true),
-            'body' => $body,
+            'body'    => $body,
         ]);
     }
 
@@ -104,7 +105,7 @@ class Engine
         $size = $builder->getSearch()->getSize();
         return $this->performSearch(
             $builder,
-            ! is_null($from)
+            !is_null($from)
                 ? ['size' => $size, 'from' => $from]
                 : []
         );
@@ -130,7 +131,7 @@ class Engine
     {
         $result = $this->performCount($query);
 
-        return isset($result['count']) ? (int) $result['count'] : 0;
+        return isset($result['count']) ? (int)$result['count'] : 0;
     }
 
     /**
@@ -143,12 +144,13 @@ class Engine
         return collect($results['hits']['hits'])->pluck('_id');
     }
 
+
     /**
      * Map the given results to instances of the given model.
      *
      * @param mixed $results
      */
-    public function map(Builder $builder, $results, Model $model): ModelCollection
+    public function map(Builder $builder, $results, Model $model)
     {
         if ($this->getTotalCount($results) === 0) {
             return $model->newCollection();
@@ -158,14 +160,26 @@ class Engine
 
         $idPositions = array_flip($ids);
 
-        return $model->getScoutModelsByIds(
+        $res = $model->getScoutModelsByIds(
             $builder,
             $ids
         )->filter(function ($model) use ($ids) {
             return in_array($model->getScoutKey(), $ids);
         })->sortBy(function ($model) use ($idPositions) {
             return $idPositions[$model->getScoutKey()];
-        })->values();
+        })->keyBy($model->getKeyName());
+
+
+        return collect($results['hits']['hits'])->map(function ($hit) use ($res) {
+            $one = $res[$hit['_id']];
+
+            if (isset($hit['highlight'])) {
+                foreach ($hit['highlight'] as $key => $value) {
+                    $one->{$key} = $value[0];
+                }
+            }
+            return $one;
+        });
     }
 
     /**
@@ -175,7 +189,7 @@ class Engine
      */
     public function getTotalCount($results): int
     {
-        return (int) $results['hits']['total']['value'];
+        return (int)$results['hits']['total']['value'];
     }
 
     /**
@@ -185,8 +199,8 @@ class Engine
     {
         $this->elasticsearch->deleteByQuery([
             'refresh' => config('scout.document_refresh', true),
-            'index' => $model->searchableAs(),
-            'body' => [
+            'index'   => $model->searchableAs(),
+            'body'    => [
                 'query' => ['match_all' => []],
             ],
         ]);
@@ -227,8 +241,8 @@ class Engine
     protected function performCount(Builder $builder, array $options = [])
     {
         $query = [
-            'index' => $builder->index ?? $builder->model->searchableAs(),
-            'body' => $builder->toArray(),
+            'index'            => $builder->index ?? $builder->model->searchableAs(),
+            'body'             => $builder->toArray(),
             'ignore_throttled' => false,
         ];
 
@@ -243,8 +257,8 @@ class Engine
     protected function performSearch(Builder $builder, array $options = [])
     {
         $query = [
-            'index' => $builder->index ?: $builder->model->searchableAs(),
-            'body' => $builder->toArray(),
+            'index'            => $builder->index ?: $builder->model->searchableAs(),
+            'body'             => $builder->toArray(),
             'ignore_throttled' => false,
         ];
 
@@ -254,6 +268,16 @@ class Engine
 
         if (isset($options['from'])) {
             $query['from'] = $options['from'];
+        }
+
+        $scoutSettings = $builder->model->searchSettings ?? [];
+
+        // 高亮
+        if ($scoutSettings && isset($scoutSettings['attributesToHighlight'])) {
+            $attributes = $scoutSettings['attributesToHighlight'];
+            foreach ($attributes as $attribute) {
+                $query['body']['highlight']['fields'][$attribute] = new \stdClass();
+            }
         }
 
         if ($builder->callback) {

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -169,7 +169,6 @@ class Engine
             return $idPositions[$model->getScoutKey()];
         })->keyBy($model->getKeyName());
 
-
         return collect($results['hits']['hits'])->map(function ($hit) use ($res) {
             $one = $res[$hit['_id']];
 
@@ -270,13 +269,17 @@ class Engine
             $query['from'] = $options['from'];
         }
 
-        $scoutSettings = $builder->model->getScoutSettings() ?? [];
+        $searchSetting = $builder->model->searchSetting ?? [];
 
-        // highlight
-        if ($scoutSettings && isset($scoutSettings['attributesToHighlight'])) {
-            $attributes = $scoutSettings['attributesToHighlight'];
-            foreach ($attributes as $attribute) {
-                $query['body']['highlight']['fields'][$attribute] = new \stdClass();
+        // 高亮
+        if ($searchSetting && isset($searchSetting['attributesToHighlight'])) {
+            $attributes = $searchSetting['attributesToHighlight'];
+            foreach ($attributes as $key => $attribute) {
+                if (is_array($attribute)) {
+                    $query['body']['highlight']['fields'][$key] = $attribute;
+                } else {
+                    $query['body']['highlight']['fields'][$attribute] = new \stdClass();
+                }
             }
         }
 

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -270,9 +270,9 @@ class Engine
             $query['from'] = $options['from'];
         }
 
-        $scoutSettings = $builder->model->searchSettings ?? [];
+        $scoutSettings = $builder->model->getScoutSettings() ?? [];
 
-        // 高亮
+        // highlight
         if ($scoutSettings && isset($scoutSettings['attributesToHighlight'])) {
             $attributes = $scoutSettings['attributesToHighlight'];
             foreach ($attributes as $attribute) {


### PR DESCRIPTION
### 配置 Elasticsearch 搜索设置

搜索设置可以通过在模型中添加 `searchSetting` 属性来配置，目前只支持高亮：

```php
<?php

declare(strict_types=1);

namespace App\Models;

use Hyperf\Database\Model\Model;
use HyperfExt\Scout\Searchable;

class Post extends Model
{
    use Searchable;

      // 搜索 `searchSetting` 配置
      public $searchSetting = [
        //高亮
        'attributesToHighlight' => [
            'title' => ["pre_tags" => "<b style='color:red'>", "post_tags" => "</b>"],
            'content'
        ],
    ];
}
```